### PR TITLE
Avoid confusion in Job Submission section

### DIFF
--- a/docs/about-bacalhau/architecture.md
+++ b/docs/about-bacalhau/architecture.md
@@ -89,7 +89,7 @@ The publisher interface is responsible for uploading the local folder of results
 
 ### Job Submission
 
-Jobs submitted via the Bacalhau CLI are forwarded to a Bacalhau network node at `bootstrap.production.bacalhau.org` via port 1234 by default. This Bacalhau node will act as the requestor node for the duration of the job lifecycle. Jobs can also be submitted to any requestor node on any other Bacalhau network.
+Jobs submitted via the Bacalhau CLI are forwarded to a Bacalhau network node at `bootstrap.production.bacalhau.org` via port 1234 by default. This Bacalhau node will act as the requestor node for the duration of the job lifecycle. Jobs can also be submitted to any requestor node on the Bacalhau network.
 
 When jobs are submitted to the requestor node, all compute nodes hear of this new job and can choose to `bid` on it. The job deal will have a `concurrency` setting, which refers to how many different nodes you may want to run this job. It will also have `confidence` and `min-bids` properties.  Confidence is how many verification proposals must agree for the job to be deemed successful. `Min-bids` is how many bids must have been made before we will choose to accept any.
 


### PR DESCRIPTION
As far as I know there is no `any other` Bacalhau network, I think is better `the` to avoid any confusion