### PR TITLE
updated all instances of links to slack with a bit.ly acct

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We would **love ❤️ your help** to improve existing items or make new ones ev
 If you find any inconsistencies in the docs, please raise an issue [here →](https://github.com/bacalhau-project/docs.bacalhau.org/issues). Feel free to also submit a pull request with any changes you'd like to see to this repo. Every contribution is more than welcome! 🎈
 
 ## Be Part of the community
-If you have any questions you can join our [Slack Community](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ) go to **#bacalhau** channel - its open to anyone!
+If you have any questions you can join our [Slack Community](https://bit.ly/bacalhau-project-slack) go to **#bacalhau** channel - its open to anyone!
 
 
 ## Resources

--- a/docs/community/social-media.md
+++ b/docs/community/social-media.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-sidebar_label: 'Social Media'
-description: 'Find Bacalhau on your favorite social media platform'
+sidebar_label: "Social Media"
+description: "Find Bacalhau on your favorite social media platform"
 ---
 
 # Social Media
@@ -14,17 +14,17 @@ The [Bacalhau YouTube channel](https://www.youtube.com/channel/UC45IQagLzNR3wdNC
 
 ## Blog and Newsletter
 
-Subscribe to the [Bacalhau newsletter](https://bacalhau.substack.com/) for official project updates sent straight to your inbox. 
+Subscribe to the [Bacalhau newsletter](https://bacalhau.substack.com/) for official project updates sent straight to your inbox.
 
 Also, our blog contains product updates, company news, and educational content on how you can leverage Bacalhau and the Compute over Data ecosytem [Bacalhau Blog](https://bacalhau.substack.com/).
 
 ## Twitter
 
-You can follow our twitter account [@Project Bacalhau](https://twitter.com/BacalhauProject)  to get Bacalhau news, product updates, etc in tweet-sized bites.
+You can follow our twitter account [@Project Bacalhau](https://twitter.com/BacalhauProject) to get Bacalhau news, product updates, etc in tweet-sized bites.
 
 ## Need Support?
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)
 
 ## Contributing
 

--- a/docs/community/style-guide.md
+++ b/docs/community/style-guide.md
@@ -179,7 +179,7 @@ Italics should be used in inline list. For example (e.g, _easy_, _simple_, _quic
 
 ## Need Support?
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)
 
 ## Contributing
 

--- a/docs/community/ways-to-contribute.md
+++ b/docs/community/ways-to-contribute.md
@@ -9,7 +9,7 @@ description: 'How to contribute to Bacalhau'
 If you want to contribute to Bacalhau and the Compute ecosystem, we have provided a quick listing of things we need help with and how you can get started.
 
 :::info
-We welcome your contributions ❤️. If what you want to do is not listed here or you need more guidance, do reach out to us on [Slack (#bacalhau channel)](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ)
+We welcome your contributions ❤️. If what you want to do is not listed here or you need more guidance, do reach out to us on [Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)
 :::
 
 ## Code

--- a/docs/examples/workload-onboarding/bacalhau-docker-image/index.md
+++ b/docs/examples/workload-onboarding/bacalhau-docker-image/index.md
@@ -178,5 +178,5 @@ After the download has finished you should see the following contents in results
 
 ## Need Support?
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://filecoin.io/slack)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)
 

--- a/docs/getting-started/docker-workload-onboarding.md
+++ b/docs/getting-started/docker-workload-onboarding.md
@@ -214,4 +214,4 @@ This can often be resolved by re-tagging your docker image
 
 ## Support
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/archives/C02RLM3JHUY)(#bacalhau channel)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack](https://bit.ly/bacalhau-project-slack/archives/C02RLM3JHUY)(#bacalhau channel)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -188,4 +188,4 @@ Here are a few resources that provides a deeper dive into running jobs with Baca
 
 ## Need Support?
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)

--- a/docs/getting-started/wasm-workload-onboarding.md
+++ b/docs/getting-started/wasm-workload-onboarding.md
@@ -98,4 +98,4 @@ See [the Rust example](../examples/workload-onboarding/rust-wasm/index.md) for a
 ## Support
 
 
-If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/archives/C02RLM3JHUY)(#bacalhau channel)
+If have questions or need support or guidance, please reach out to the [Bacalhau team via Slack](https://bit.ly/bacalhau-project-slack/archives/C02RLM3JHUY)(#bacalhau channel)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -110,7 +110,7 @@ Our mission is to transform the way that compute is run globally. You can find B
 Bacalhau has a very friendly community and we are always happy to help you get started:
 
 - [GitHub Discussions](https://github.com/bacalhau-project/bacalhau/discussions) – ask anything about the project, give feedback or answer questions that will help other users.
-- [Join the Slack Community](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ) and go to **#bacalhau** channel – it is the easiest way engage with other members in the community and get help.
+- [Join the Slack Community](https://bit.ly/bacalhau-project-slack) and go to **#bacalhau** channel – it is the easiest way engage with other members in the community and get help.
 - [Contributing](https://docs.bacalhau.org/community/ways-to-contribute) – learn how to contribute to the Bacalhau project.
 
 ## Next Steps

--- a/docs/quick-start-pvt-cluster.md
+++ b/docs/quick-start-pvt-cluster.md
@@ -19,4 +19,4 @@ Good news. Spinning up a private cluster is really a piece of cake :cake::
 
 Optionally, set up [systemd](https://en.wikipedia.org/wiki/Systemd) units make Bacalhau daemons permanent , here's an example [systemd service file](https://github.com/bacalhau-project/bacalhau/blob/main/ops/terraform/remote_files/configs/bacalhau.service).
 
-Please contact us on [Slack](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/) `#bacalhau` channel for questions and feedback!
+Please contact us on [Slack](https://bit.ly/bacalhau-project-slack/) `#bacalhau` channel for questions and feedback!

--- a/docs/running-node/quick-start.md
+++ b/docs/running-node/quick-start.md
@@ -21,7 +21,7 @@ To bootstrap your node and join the network as a CP you can leap right into the 
 
 :::info
 
-If you run on a different system than Ubuntu, drop us a message on [Slack](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/archives/C02RLM3JHUY)!
+If you run on a different system than Ubuntu, drop us a message on [Slack](https://bit.ly/bacalhau-project-slack/archives/C02RLM3JHUY)!
 We'll add instructions for your favorite OS.
 
 :::
@@ -178,7 +178,7 @@ To ensure that our node can communicate with other nodes on the network - we nee
 
 (Optional) To ensure the cli can communicate with our node directly (i.e. `bacalhau --api-host <MY_NODE_PUBLIC_IP> version`) - we need to make sure the **1234** port is open.
 
-Firewall configuration is very specific to your network and we can't provide generic instructions for this step but if you need any help feel free to reach out on [Slack!](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/archives/C02RLM3JHUY)
+Firewall configuration is very specific to your network and we can't provide generic instructions for this step but if you need any help feel free to reach out on [Slack!](https://bit.ly/bacalhau-project-slack/archives/C02RLM3JHUY)
 
 ### Install the Bacalhau Binary
 
@@ -233,4 +233,4 @@ If you see logs of your computenode bidding for the job above it means you've su
 ### What's next?
 
 At this point you probably have a number of questions for us. What incentive should you expect for running a public Bacalhau node?
-Please contact us on [Slack](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ/archives/C02RLM3JHUY) to further discuss this topic and for sharing your valuable feedback.
+Please contact us on [Slack](https://bit.ly/bacalhau-project-slack/archives/C02RLM3JHUY) to further discuss this topic and for sharing your valuable feedback.

--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -149,7 +149,7 @@ In essence, you should try and derisk the job by intentionally testing all the n
 
 ## Support
 
-If you're still having trouble, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://join.slack.com/t/bacalhauproject/shared_invite/zt-1sihp4vxf-TjkbXz6JRQpg2AhetPzYYQ)
+If you're still having trouble, please reach out to the [Bacalhau team via Slack (#bacalhau channel)](https://bit.ly/bacalhau-project-slack)
 
 ## Contributing
 


### PR DESCRIPTION
Slack invites expire every x number of days, so it's easier to link to a bit.ly that we can all update (info in notion) so we can update across the board.

FYI it is bit.ly/bacalhau-project-slack