### PR TITLE
docs: ucan invocation reasonable defaults

### DIFF
--- a/docs/all-flags.md
+++ b/docs/all-flags.md
@@ -135,26 +135,37 @@ There is no support for sharding, concurrency or minimum bidding for these jobs.
 
 #### Examples
 
+Refers to example models at balcalhau repository under [pkg/model/tasks](https://github.com/bacalhau-project/bacalhau/tree/main/pkg/model/tasks)
+
 An example UCAN Invocation that runs the same job as the above example would look like:
 
 ```json
 {
-    "with": "ubuntu",
-    "do": "docker/run",
-    "inputs": {
-        "entrypoint": ["echo", "hello", "world"],
-        "workdir": "/",
-        "mounts": {},
-        "outputs": {
-            "/outputs": ""
-        },
-    },
-    "meta": {
-        "bacalhau/config": {
-            "verifier": 1,
-            "publisher": 4,
-        }
+  "with": "ubuntu",
+  "do": "docker/run",
+  "inputs": {
+    "entrypoint": ["echo", "hello", "world"],
+    "workdir": "/",
+    "mounts": {},
+    "outputs": {
+      "/outputs": ""
     }
+  },
+  "meta": {
+    "bacalhau/config": {
+      "verifier": 1,
+      "publisher": 4,
+      "annotations": ["hello"],
+      "resources": {
+        "cpu": 1,
+        "disk": 1073741824,
+        "memory": 1073741824,
+        "gpu": 0
+      },
+      "timeout": 300e9,
+      "dnt": false
+    }
+  }
 }
 ```
 
@@ -178,9 +189,6 @@ An example UCAN Invocation that runs a WebAssembly job might look like:
 		}
 	},
 	"meta": {
-    "bacalhau/config": {
-        "verifier": 2,
-        "publisher": 4,
     }
   }
 }

--- a/docs/running-node/networking.md
+++ b/docs/running-node/networking.md
@@ -84,7 +84,7 @@ You can use the `--host` flag to restrict network access to the REST api.
 You can call [http://dashboard.bacalhau.org:1000/api/v1/run](http://dashboard.bacalhau.org:1000/api/v1/run) with the POST body as a JSON serialized spec
 
 ```bash
-curl -XPOST -d '{"Engine": "Docker", "Docker": {"Image": "ubuntu", "Entrypoint": ["echo", "hello"]}, "Deal": {"Concurrency": 1}, "Verifier": "Noop", "Publisher": "IPFS"}' 'http://dashboard.bacalhau.org:1000/api/v1/run'; echo
+curl -XPOST -d '{"Engine": "Docker", "Docker": {"Image": "ubuntu", "Entrypoint": ["echo", "hello"]}, "Deal": {"Concurrency": 1}, "Verifier": "Noop", "PublisherSpec":{"Type":"IPFS"}}' 'http://dashboard.bacalhau.org:1000/api/v1/run';
 ```
 
 Once you run the command above, you'll get a CID output:


### PR DESCRIPTION
Regarding https://github.com/bacalhau-project/bacalhau/issues/1506,  understand the sample ucan json is for intuition and to align the one in YAML, while it will be great if it is something executable especially for people new to bacalhau, and more detailed validation error messages is provided 

Running per docs will get below errors as some fields are not optional per [schema](https://github.com/bacalhau-project/bacalhau/blob/0c9551b51590de884cdf16aef701a98798bd4c9c/pkg/model/task.go#L36) 

We could either point to original repo's sample files or omit the optional config to simplify. (PR to illustrate the point) 

```
LOG_LEVEL=DEBUG bacalhau create ./job.json
17:25:03.851 | DBG pkg/system/environment.go:53 > Defaulting to production environment: 
 os.Args: [bacalhau create ./job.json]
17:25:03.871 | DBG pkg/system/config.go:202 > BACALHAU_DIR not set, using default of ~/.bacalhau
17:25:03.872 | DBG pkg/telemetry/tracing.go:26 > OLTP tracing endpoints are not defined. No traces will be exported
17:25:03.872 | DBG pkg/telemetry/metrics.go:22 > OLTP metrics endpoints are not defined. No metrics will be exported
The job provided is invalid.
```

Thanks for the amazing work!