### PR TITLE
Correct flaw in python example

### DIFF
--- a/docs/sdk/python-sdk.md
+++ b/docs/sdk/python-sdk.md
@@ -68,6 +68,7 @@ from bacalhau_apiclient.models.job_spec_language import JobSpecLanguage
 from bacalhau_apiclient.models.job_spec_docker import JobSpecDocker
 from bacalhau_apiclient.models.job_sharding_config import JobShardingConfig
 from bacalhau_apiclient.models.job_execution_plan import JobExecutionPlan
+from bacalhau_apiclient.models.publisher_spec import PublisherSpec
 from bacalhau_apiclient.models.deal import Deal
 
 
@@ -77,7 +78,7 @@ data = dict(
     Spec=Spec(
         engine="Docker",
         verifier="Noop",
-        publisher="Estuary",
+        publisher_spec=PublisherSpec(type="Estuary"),
         docker=JobSpecDocker(
             image="ubuntu",
             entrypoint=["echo", "Hello World!"],


### PR DESCRIPTION
We recently(ish) had to change publisher= to publisher_spec= and this PR should update the example here to match the version at https://github.com/bacalhau-project/bacalhau/blob/main/python/examples/submit_job.py 