### PR TITLE
Document options for persistence on compute/requester nodes

### DIFF
--- a/docs/running-node/persistence.md
+++ b/docs/running-node/persistence.md
@@ -14,7 +14,7 @@ The computes nodes maintain information about the work that has been allocated t
 * The current state of the execution, and
 * The original job that resulted in this allocation 
 
-This information is used by the compute and requester nodes to ensure allocated jobs are completed successfully.  By default, compute nodes store their state in a bolt-db database and this is located in the bacalhau configuration folder.  For a compute node whose ID is "abc", the database can be found in `~/.bacalhau/abc-compute/executions.db`.
+This information is used by the compute and requester nodes to ensure allocated jobs are completed successfully.  By default, compute nodes store their state in a bolt-db database and this is located in the bacalhau repository along with configuration data.  For a compute node whose ID is "abc", the database can be found in `~/.bacalhau/abc-compute/executions.db`.
 
 In some cases, it may be preferable to maintain the state in memory, with the caveat that should the node restart, all state will be lost.  This can be configured using the environment variables in the table below.
 
@@ -26,7 +26,7 @@ In some cases, it may be preferable to maintain the state in memory, with the ca
 
 ## Requester node persistence
 
-When running a requester node, it maintains state about the jobs it has been requested to orchestrate and schedule, the evaluation of those jobs, and the executions that have been allocated.  By default, this state is stored in a bolt db database that, with a node ID of "xyz" can be found in `~/.bacalhau/xyz-requester/jobs.db`.
+When running a requester node, it maintains state about the jobs it has been requested to orchestrate and schedule, the evaluation of those jobs, and the executions that have been allocated.  By default, this state is stored in a bolt db database that, with a node ID of "xyz" can be found in  `~/.bacalhau/xyz-requester/jobs.db`.
 
 It is possible, but not recommended, to run the requester node with an inmemory job store, which will result in lost state when the requester node is restarted.  
 

--- a/docs/running-node/persistence.md
+++ b/docs/running-node/persistence.md
@@ -12,7 +12,7 @@ Both compute nodes, and requester nodes, maintain state. How that state is maint
 The computes nodes maintain information about the work that has been allocated to them, including:
 
 * The current state of the execution, and
-* The original job that that resulted in this allocation 
+* The original job that resulted in this allocation 
 
 This information is used by the compute and requester nodes to ensure allocated jobs are completed successfully.  By default, compute nodes store their state in a bolt-db database and this is located in the bacalhau configuration folder.  For a compute node whose ID is "abc", the database can be found in `~/.bacalhau/abc-compute/executions.db`.
 

--- a/docs/running-node/persistence.md
+++ b/docs/running-node/persistence.md
@@ -1,0 +1,37 @@
+---
+sidebar_label: 'Configuring node persistence'
+sidebar_position: 180
+title: 'Configuring node persistence'
+description: How to configure compute/requester persistence
+---
+
+Both compute nodes, and requester nodes, maintain state. How that state is maintained is configurable, although the defaults are likely adequate for most use-cases.  This page describes how to configure the persistence of compute and requester nodes should the defaults not be suitable.  
+
+## Compute node persistence 
+
+The computes nodes maintain information about the work that has been allocated to them, including:
+
+* The current state of the execution, and
+* The original job that that resulted in this allocation 
+
+This information is used by the compute and requester nodes to ensure allocated jobs are completed successfully.  By default, compute nodes store their state in a bolt-db database and this is located in the bacalhau configuration folder.  For a compute node whose ID is "abc", the database can be found in `~/.bacalhau/abc-compute/executions.db`.
+
+In some cases, it may be preferable to maintain the state in memory, with the caveat that should the node restart, all state will be lost.  This can be configured using the environment variables in the table below.
+
+|Environment Variable|Flag alternative|Value|Effect|
+|--|--|--|--|
+|BACALHAU_COMPUTE_STORE_TYPE|--compute-execution-store-type|boltdb|Uses the bolt db execution store (default)|
+|BACALHAU_COMPUTE_STORE_PATH|--compute-execution-store-path|A path (inc. filename)|Specifies where the boltdb database should be stored. Default is `~/.bacalhau/{NODE-ID}-compute/executions.db` if not set|
+|BACALHAU_COMPUTE_STORE_TYPE|--compute-execution-store-type|inmemory|Uses the inmemory execution store|
+
+## Requester node persistence
+
+When running a requester node, it maintains state about the jobs it has been requested to orchestrate and schedule, the evaluation of those jobs, and the executions that have been allocated.  By default, this state is stored in a bolt db database that, with a node ID of "xyz" can be found in `~/.bacalhau/xyz-requester/jobs.db`.
+
+It is possible, but not recommended, to run the requester node with an inmemory job store, which will result in lost state when the requester node is restarted.  
+
+|Environment Variable|Flag alternative|Value|Effect|
+|--|--|--|--|
+|BACALHAU_JOB_STORE_TYPE|--requester-job-store-type|boltdb|Uses the bolt db job store (default)|
+|BACALHAU_JOB_STORE_PATH|--requester-job-store-path|A path (inc. filename)|Specifies where the boltdb database should be stored. Default is `~/.bacalhau/{NODE-ID}-requester/jobs.db` if not set|
+|BACALHAU_JOB_STORE_TYPE|--requester-job-store-type|inmemory|Uses the inmemory job store|

--- a/sidebars.js
+++ b/sidebars.js
@@ -176,10 +176,10 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Running Node',
+      label: 'Running a Node',
       link: {
         type: 'generated-index',
-        title: 'Running node',
+        title: 'Running a node',
         slug: '/running-node',
       },
       collapsed: true,
@@ -192,6 +192,7 @@ module.exports = {
         'running-node/resource-limits',
         'running-node/test-network',
         'running-node/gpu',
+        'running-node/persistence',
         'running-node/windows-support',
         'running-node/observability'
       ],


### PR DESCRIPTION
Adds some explanation on how to configure persistence on compute/requester nodes if the defaults are not adequate.