### PR TITLE
Update FAQs and add cli reference

### DIFF
--- a/docs/all-flags.md
+++ b/docs/all-flags.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 
 :::info
 
-The following commands refer to bacalhau cli version `v0.3.29`.
+The following commands refer to bacalhau cli version `v1.0.3`.
 For installing or upgrading a client, follow the instructions in the [installation page](https://docs.bacalhau.org/getting-started/installation).
 Run `bacalhau version` in a terminal to check what version you have.
 

--- a/docs/troubleshooting/faqs.md
+++ b/docs/troubleshooting/faqs.md
@@ -51,7 +51,7 @@ Networking is supported by Bacalhau which enables one to run a script that requi
 
 ## How do I see a job’s progress while it’s running?
 
-That's currently not possible
+If your job writes to stdout, or stderr, while it is running, you can view the output with the [logs](https://docs.bacalhau.org/all-flags/#logs) command.
 
 ## How do I get an IPFS peer if I want to start Bacalhau Server?
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -222,6 +222,7 @@ module.exports = {
       items: [
         'troubleshooting/debugging',
         'troubleshooting/faqs',   
+        'all-flags',
       ],
     },
     {


### PR DESCRIPTION
Adds an update on viewing job output in the FAQs.
Also adds CLI reference to the FAQs section (as we don't have a reference section) so that it isn't free-floating and is accessible without hunting down a link.