### PR TITLE
Add an explanation page for job types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ package-lock.json
 env.*
 .env
 
-job-[a-zA-Z0-9]*
+./job-[a-zA-Z0-9]*

--- a/docs/topic-guides/_category.yml
+++ b/docs/topic-guides/_category.yml
@@ -1,2 +1,0 @@
-label: "Topic Guides"
-position: 7

--- a/docs/topic-guides/_category.yml
+++ b/docs/topic-guides/_category.yml
@@ -1,0 +1,2 @@
+label: "Topic Guides"
+position: 7

--- a/docs/topic-guides/index.md
+++ b/docs/topic-guides/index.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: 'Topic Guides'
+sidebar_position: 0
+title: 'Topic Guides'
+---
+
+# Topic Guides
+
+Topic guides give a high level view of key topics and concepts, and provides useful background information and explanation of how Bacalhau works.
+
+
+## Jobs 
+
+[Job Types](job-types)   
+Bacalhau supports different types of jobs,
+with different lifetimes and scheduling behaviours.
+This guide describes the various types of job,
+and what they might be used for.

--- a/docs/topic-guides/index.md
+++ b/docs/topic-guides/index.md
@@ -1,6 +1,4 @@
 ---
-sidebar_label: 'Topic Guides'
-sidebar_position: 0
 title: 'Topic Guides'
 ---
 

--- a/docs/topic-guides/job-types.md
+++ b/docs/topic-guides/job-types.md
@@ -17,15 +17,9 @@ Despite the differences in job types, all jobs benefit from core functionalities
 
 ## Batch Jobs
 
-Batch jobs are typically executed on demand and they operate on a designated number of Bacalhau nodes.  It is expected that batch jobs perform a single discrete task before completing. 
+Batch jobs are executed on demand, running on a specified number of Bacalhau nodes. These jobs either run until completion or until they reach a timeout. They are designed to carry out a single, discrete task before finishing.
 
-Ideal for intermittent yet intensive data dives, for instance performing comp;utation over large datasets before publishing the response.  This approach eliminates the continuous processing overhead, focusing on specific, in-depth investigations and computation.
-
-## Daemon Jobs
-
-Daemon jobs run continuously on all nodes that meet the criteria given in the job specification. Should any new compute nodes join the cluster after the job was started, and should they meet the criteria, the job will be scheduled to run on that node too. 
-
-A good application of daemon jobs is to handle continuously generated data on every compute node.  This might be from edge devices like sensors, or cameras, or from logs where they are generated. The data can then be aggregated and compressed them before sending it onwards.  For logs, the aggregated data can be relayed at regular intervals to platforms like Kafka or Kinesis, or directly to other logging services with edge devices potentially delivering results via MQTT. 
+Ideal for intermittent yet intensive data dives, for instance performing computation over large datasets before publishing the response.  This approach eliminates the continuous processing overhead, focusing on specific, in-depth investigations and computation.
 
 ## Ops Jobs
 
@@ -33,8 +27,14 @@ Similar to batch jobs, ops jobs have a broader reach. They are executed on all n
 
 Ops jobs are perfect for urgent investigations, granting direct access to logs on host machines, where previously you may have had to wait for the logs to arrive at a central locartion before being able to query them. They can also be used for delivering configuration files for other systems should you wish to deploy an update to many machines at once. 
 
+## Daemon Jobs
+
+Daemon jobs run continuously on all nodes that meet the criteria given in the job specification. Should any new compute nodes join the cluster after the job was started, and should they meet the criteria, the job will be scheduled to run on that node too.
+
+A good application of daemon jobs is to handle continuously generated data on every compute node.  This might be from edge devices like sensors, or cameras, or from logs where they are generated. The data can then be aggregated and compressed them before sending it onwards.  For logs, the aggregated data can be relayed at regular intervals to platforms like Kafka or Kinesis, or directly to other logging services with edge devices potentially delivering results via MQTT. 
+
 ## Service Jobs
 
-These jobs run like daemon jobs but only on a specified number of nodes. The orchestrator in Bacalhau selects the optimal nodes to run the job, ensuring its health and performance.
+Service jobs run continuously on a specified number of nodes that meet the criteria given in the job specification. Bacalhau's orchestrator selects the optimal nodes to run the job, and continuously monitors its health, performance. If required it will reschedule on other nodes.
 
-Service jobs can be used for similar tasks to Daemon jobs, but are used for occasions where it does not need to be run on every single machine, and where optimal node selection is preferred. This can be used for limited scale long-running jobs to provide services to other jobs, such as mail-delivery, or a KV store for job-specific state.
+This job type is good for long running consumers such as streaming or queueing services, or real-time event listeners. 

--- a/docs/topic-guides/job-types.md
+++ b/docs/topic-guides/job-types.md
@@ -8,7 +8,7 @@ description: The different job types available in Bacalhau
 Bacalhau has recently introduced different job types in v1.1,
 providing more control and flexibility over the orchestration and scheduling of those jobs - depending on their type.
 
-One thing that each job has in common is that Bacalhau provides common functionality for them including:
+Despite the differences in job types, all jobs benefit from core functionalities provided by Bacalhau, including:```
 
 1. **Node selection** - the appropriate nodes are selected based on several criteria, including resource availability, priority and feedback from the nodes.
 2. **Task monitoring** - tasks are monitored to ensure they complete, and that they stay in a healthy state.  

--- a/docs/topic-guides/job-types.md
+++ b/docs/topic-guides/job-types.md
@@ -1,0 +1,40 @@
+---
+sidebar_label: 'Job types'
+sidebar_position: 0
+title: 'Job types'
+description: The different job types available in Bacalhau
+---
+
+Bacalhau has recently introduced different job types in v1.1,
+providing more control and flexibility over the orchestration and scheduling of those jobs - depending on their type.
+
+One thing that each job has in common is that Bacalhau provides common functionality for them including:
+
+1. **Node selection** - the appropriate nodes are selected based on several criteria, including resource availability, priority and feedback from the nodes.
+2. **Task monitoring** - tasks are monitored to ensure they complete, and that they stay in a healthy state.  
+3. **Retries** - within limits, Bacalhau will retry certain jobs a set number of times should it fail to complete successfully when requested.
+
+
+## Batch Jobs
+
+Batch jobs are typically executed on demand and they operate on a designated number of Bacalhau nodes.  It is expected that batch jobs perform a single discrete task before completing. 
+
+Ideal for intermittent yet intensive data dives, for instance performing comp;utation over large datasets before publishing the response.  This approach eliminates the continuous processing overhead, focusing on specific, in-depth investigations and computation.
+
+## Daemon Jobs
+
+Daemon jobs run continuously on all nodes that meet the criteria given in the job specification. Should any new compute nodes join the cluster after the job was started, and should they meet the criteria, the job will be scheduled to run on that node too. 
+
+A good application of daemon jobs is to handle continuously generated data on every compute node.  This might be from edge devices like sensors, or cameras, or from logs where they are generated. The data can then be aggregated and compressed them before sending it onwards.  For logs, the aggregated data can be relayed at regular intervals to platforms like Kafka or Kinesis, or directly to other logging services with edge devices potentially delivering results via MQTT. 
+
+## Ops Jobs
+
+Similar to batch jobs, ops jobs have a broader reach. They are executed on all nodes that align with the job specification, but otherwise behave like batch jobs.
+
+Ops jobs are perfect for urgent investigations, granting direct access to logs on host machines, where previously you may have had to wait for the logs to arrive at a central locartion before being able to query them. They can also be used for delivering configuration files for other systems should you wish to deploy an update to many machines at once. 
+
+## Service Jobs
+
+These jobs run like daemon jobs but only on a specified number of nodes. The orchestrator in Bacalhau selects the optimal nodes to run the job, ensuring its health and performance.
+
+Service jobs can be used for similar tasks to Daemon jobs, but are used for occassions where it does not need to be run on every single machine, and where optimal node selection is preferred. This can be used for limited scale long-running jobs to provide services to other jobs, such as mail-delivery, or a KV store for job-specific state.

--- a/docs/topic-guides/job-types.md
+++ b/docs/topic-guides/job-types.md
@@ -11,7 +11,7 @@ providing more control and flexibility over the orchestration and scheduling of 
 Despite the differences in job types, all jobs benefit from core functionalities provided by Bacalhau, including:```
 
 1. **Node selection** - the appropriate nodes are selected based on several criteria, including resource availability, priority and feedback from the nodes.
-2. **Task monitoring** - tasks are monitored to ensure they complete, and that they stay in a healthy state.  
+2. **Job monitoring** - jobs are monitored to ensure they complete, and that they stay in a healthy state.  
 3. **Retries** - within limits, Bacalhau will retry certain jobs a set number of times should it fail to complete successfully when requested.
 
 

--- a/docs/topic-guides/job-types.md
+++ b/docs/topic-guides/job-types.md
@@ -37,4 +37,4 @@ Ops jobs are perfect for urgent investigations, granting direct access to logs o
 
 These jobs run like daemon jobs but only on a specified number of nodes. The orchestrator in Bacalhau selects the optimal nodes to run the job, ensuring its health and performance.
 
-Service jobs can be used for similar tasks to Daemon jobs, but are used for occassions where it does not need to be run on every single machine, and where optimal node selection is preferred. This can be used for limited scale long-running jobs to provide services to other jobs, such as mail-delivery, or a KV store for job-specific state.
+Service jobs can be used for similar tasks to Daemon jobs, but are used for occasions where it does not need to be run on every single machine, and where optimal node selection is preferred. This can be used for limited scale long-running jobs to provide services to other jobs, such as mail-delivery, or a KV store for job-specific state.

--- a/sidebars.js
+++ b/sidebars.js
@@ -146,6 +146,18 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Topic Guides',
+      link: {
+        type: 'doc',
+        id: 'topic-guides/index',
+      },
+      collapsed: true,
+      items: [
+        'topic-guides/job-types'
+      ],
+    },    
+    {
+      type: 'category',
       label: 'Data Ingestion',
       link: {
         type: 'generated-index',


### PR DESCRIPTION
Adds an explanation of the different job types, and how they might be used, and adds them to a new Topic Guides section.  This corresponds to the fourth type of documentation (Explanation) and should contain explanatory articles providing background and context for readers interested in gaining understanding.

We probably want to also add a How-to page for using the different jobs types.