### PR TITLE
Rewrite /sdk to the SDK homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@akebifiky/remark-simple-plantuml": "^1.0.2",
     "@docusaurus/core": "^2.1.0",
-    "@docusaurus/plugin-client-redirects": "^2.4.3",
+    "@docusaurus/plugin-client-redirects": "^2.4.1",
     "@docusaurus/plugin-google-gtag": "^2.1.0",
     "@docusaurus/preset-classic": "^2.1.0",
     "@docusaurus/types": "^2.1.0",

--- a/redirects.js
+++ b/redirects.js
@@ -1,3 +1,4 @@
 module.exports = [
     { to: '/references/sdk/python-sdk', from: '/sdk/python-sdk' },
+    { to: '/category/sdk', from: '/sdk' },
 ];


### PR DESCRIPTION
Strangely, /sdk is in /category/sdk whilst /python-sdk is in /references/sdk/python-sdk.

Also make sure redirect plugin is the same version as docusaurus to reduce the amount of noise about matching versions.